### PR TITLE
Update sshd_config - Removing PrintLastLog from default config

### DIFF
--- a/overlay/generic/etc/ssh/sshd_config
+++ b/overlay/generic/etc/ssh/sshd_config
@@ -110,7 +110,7 @@ X11UseLocalhost yes
 # Should sshd print the /etc/motd file and check for mail.
 # On Solaris it is assumed that the login shell will do these (eg /etc/profile).
 PrintMotd no
-PrintLastLog no
+#PrintLastLog no
 
 #TCPKeepAlive yes
 #UseLogin no


### PR DESCRIPTION
[ Jan  2 08:50:48 Stopping because service disabled. ]
[ Jan  2 08:50:48 Executing stop method (:kill). ]
[ Jan  2 08:50:50 Enabled. ]
[ Jan  2 08:50:50 Executing start method ("/lib/svc/method/sshd start"). ]
/etc/ssh/sshd_config line 113: Unsupported option PrintLastLog
[ Jan  2 08:50:50 Method "start" exited with status 0. ]