### PR TITLE
OS-8398 Enabling allow_dhcp_spoofing should remove ip-nospoof

### DIFF
--- a/src/vm/man/vmadm.8.md
+++ b/src/vm/man/vmadm.8.md
@@ -1486,7 +1486,8 @@ tab-complete UUIDs rather than having to type them out for every command.
 
         With this property set to true, this VM will be able to operate as a
         DHCP server on this interface.  Without this, some of the packets
-        required of a DHCP server will not get through.
+        required of a DHCP server will not get through. This property also
+        implies the behavior of allow_ip_spoofing.
 
         type: boolean
         vmtype: ANY
@@ -1588,18 +1589,9 @@ tab-complete UUIDs rather than having to type them out for every command.
         create: yes
         update: yes
 
-    nics.*.dhcp_server:
+    nics.*.dhcp_server (DEPRECATED):
 
-        With this property set to true, this VM will be able to operate as a
-        DHCP server on this interface.  Without this, some of the packets
-        required of a DHCP server will not get through.
-
-        type: boolean
-        vmtype: ANY
-        listable: yes (see above)
-        create: yes
-        update: yes
-        default: false
+        This option behaves identically to allow_dhcp_spoofing.
 
     nics.*.gateway (DEPRECATED):
 

--- a/src/vm/node_modules/VM.js
+++ b/src/vm/node_modules/VM.js
@@ -15398,8 +15398,8 @@ function updateVnicProperties(uuid, vmobj, payload, log, callback)
         }
 
         if ((vm_nic.hasOwnProperty('dhcp_server')
-                && fixBoolean(vm_nic.dhcp_server)) ||
-            (vm_nic.hasOwnProperty('allow_dhcp_spoofing')
+                && fixBoolean(vm_nic.dhcp_server))
+                || (vm_nic.hasOwnProperty('allow_dhcp_spoofing')
                 && fixBoolean(vm_nic.allow_dhcp_spoofing))) {
             delete spoof_opts.allow_dhcp_spoofing;
             delete spoof_opts.allow_ip_spoofing;

--- a/src/vm/node_modules/VM.js
+++ b/src/vm/node_modules/VM.js
@@ -21,6 +21,7 @@
  * CDDL HEADER END
  *
  * Copyright 2021 Joyent, Inc.
+ * Copyright 2022 MNX Cloud, Inc.
  *
  * Experimental functions, expect these interfaces to be unstable and
  * potentially go away entirely:
@@ -15396,8 +15397,10 @@ function updateVnicProperties(uuid, vmobj, payload, log, callback)
             }
         }
 
-        if (vm_nic.hasOwnProperty('dhcp_server')
-                && fixBoolean(vm_nic.dhcp_server)) {
+        if ((vm_nic.hasOwnProperty('dhcp_server')
+                && fixBoolean(vm_nic.dhcp_server)) ||
+            (vm_nic.hasOwnProperty('allow_dhcp_spoofing')
+                && fixBoolean(vm_nic.allow_dhcp_spoofing))) {
             delete spoof_opts.allow_dhcp_spoofing;
             delete spoof_opts.allow_ip_spoofing;
         }


### PR DESCRIPTION
Fixes #1051.