### PR TITLE
Increase maxBuffer for imgadm zfs listing

### DIFF
--- a/src/img/lib/imgadm.js
+++ b/src/img/lib/imgadm.js
@@ -856,7 +856,7 @@ IMGADM.prototype._loadImages = function _loadImages(callback) {
             log: self.log,
             errMsg: 'could not load images',
             execOpts: {
-                maxBuffer: 10485760  /* >200k hit in prod, 10M should suffice */
+                maxBuffer: 20971520  /* >200k hit in prod, 20M should suffice */
             }
         }, function (zfsErr, stdout, stderr) {
             if (zfsErr) {


### PR DESCRIPTION
The maxBuffer is not suitable for production environments with lot's of snapshots and delegate datasets. Especially when the structure contains lot's of sub-folders.

