### PR TITLE
OS-8404 git pbchk needs py39-expat dependency

### DIFF
--- a/configure
+++ b/configure
@@ -202,7 +202,7 @@ function install_pkgin
 	local pkglist
 
 	pkglist="build-essential flex libxslt openjdk11 nodejs"
-	pkglist="$pkglist p5-XML-Parser gettext python27 py27-expat python39"
+	pkglist="$pkglist p5-XML-Parser gettext python27 py39-expat python39"
 	pkglist="$pkglist coreutils gsed pkg_alternatives cdrtools"
 	pkglist="$pkglist py27-sqlite3 nasm pigz smartos-build-tools"
 


### PR DESCRIPTION
NOT mission-critical.