### PR TITLE
15655 Build scripts should tolerate make -w (fix illumos.sh)

### DIFF
--- a/configure
+++ b/configure
@@ -365,7 +365,7 @@ PARENT_TOOLS_ROOT="\$PARENT_WS/usr/src/tools/proto/root_\$MACH-nd"
 PKGARCHIVE="\${CODEMGR_WS}/packages/\${MACH}/nightly";
 						export PKGARCHIVE
 PKGPUBLISHER_REDIST="${PUBLISHER}";		export PKGPUBLISHER_REDIST
-MAKEFLAGS=k;					export MAKEFLAGS
+MAKEFLAGS=ek;					export MAKEFLAGS
 UT_NO_USAGE_TRACKING="1";			export UT_NO_USAGE_TRACKING
 MULTI_PROTO="no";				export MULTI_PROTO
 BUILD_TOOLS="\$SRC/tools/proto/root_\${MACH}-nd/opt";


### PR DESCRIPTION
May wish to file an OS-bug, or may just make this a putback buddy.  You reviewers decide.

Tested by local build and hopefully soon by https://jenkins.tritondatacenter.com/job/TritonDataCenter/job/smartos-live/job/makeflags/