### PR TITLE
OS-8469 Update default sshd_config to reduce log spam

### DIFF
--- a/src/etc/ssh/sshd_config
+++ b/src/etc/ssh/sshd_config
@@ -110,11 +110,9 @@ X11UseLocalhost yes
 # Should sshd print the /etc/motd file and check for mail.
 # On Solaris it is assumed that the login shell will do these (eg /etc/profile).
 PrintMotd no
-PrintLastLog no
 
 #TCPKeepAlive yes
 #UseLogin no
-UsePrivilegeSeparation sandbox		# Default for new installations.
 #PermitUserEnvironment no
 #Compression delayed
 #ClientAliveInterval 0


### PR DESCRIPTION
This only affects the global zone because base zone images have their own sshd_config.