### PR TITLE
LINUXCN-26 lsblk output has changed in Debian 12

### DIFF
--- a/src/disklayout.js
+++ b/src/disklayout.js
@@ -67,7 +67,7 @@ dolayout(disks, layout, nspares, excluded, enable_cache, width)
 			});
 
 			return (mountpoints.length === 0);
-		})
+		});
 	}
 
 	config = disklayout.compute(disks, layout, nspares, enable_cache,

--- a/src/disklayout.js
+++ b/src/disklayout.js
@@ -47,7 +47,7 @@ dolayout(disks, layout, nspares, excluded, enable_cache, width)
 			return (true);
 		});
 	} else if (os.type() === 'Linux') {
-		var zvolExp = /^zd[0-9a-z]*$/;
+		var zvolExp = /^zd[0-9a-z]+$/;
 		disks = disks.filter(function (disk) {
 			if (excluded.indexOf(disk.name.toLowerCase()) !== -1) {
 				return (false);

--- a/src/disklayout.js
+++ b/src/disklayout.js
@@ -47,11 +47,21 @@ dolayout(disks, layout, nspares, excluded, enable_cache, width)
 			return (true);
 		});
 	} else if (os.type() === 'Linux') {
+		var zvolExp = /^zd[0-9a-z]*$/;
 		disks = disks.filter(function (disk) {
 			if (excluded.indexOf(disk.name.toLowerCase()) !== -1) {
 				return (false);
 			}
 
+			// Filter out any zvol devices
+			// Alternatively we could pass -e MAJOR_NUM to lsblk but would need
+			// to parse /proc/devices to get the major device number for zvols
+			if (zvolExp.test(disk.name)) {
+				return (false);
+			}
+
+			// Filter out any null values from the mountpoints array
+			// If a disk has no mountpoints the array has a single null item
 			var mountpoints = disk.mountpoints.filter(function (mountpoint) {
 				return (mountpoint !== null);
 			});

--- a/src/disklayout.js
+++ b/src/disklayout.js
@@ -2,6 +2,7 @@
 
 /*
  * Copyright 2020 Joyent, Inc.
+ * Copyright 2023 MNX Cloud, Inc.
  */
 
 var fs = require('fs');
@@ -47,10 +48,15 @@ dolayout(disks, layout, nspares, excluded, enable_cache, width)
 		});
 	} else if (os.type() === 'Linux') {
 		disks = disks.filter(function (disk) {
-			if (excluded.indexOf(disk.name.toLowerCase()) !== -1)
+			if (excluded.indexOf(disk.name.toLowerCase()) !== -1) {
 				return (false);
+			}
 
-			return disk.mountpoint === null;
+			var mountpoints = disk.mountpoints.filter(function (mountpoint) {
+				return (mountpoint !== null);
+			});
+
+			return (mountpoints.length === 0);
 		})
 	}
 

--- a/src/disklayout.js
+++ b/src/disklayout.js
@@ -54,15 +54,18 @@ dolayout(disks, layout, nspares, excluded, enable_cache, width)
 			}
 
 			// Filter out any zvol devices
-			// Alternatively we could pass -e MAJOR_NUM to lsblk but would need
-			// to parse /proc/devices to get the major device number for zvols
+			// Alternatively we could pass -e MAJOR_NUM to lsblk but
+			// would need to parse /proc/devices to get the major
+			// device number for zvols
 			if (zvolExp.test(disk.name)) {
 				return (false);
 			}
 
 			// Filter out any null values from the mountpoints array
-			// If a disk has no mountpoints the array has a single null item
-			var mountpoints = disk.mountpoints.filter(function (mountpoint) {
+			// If a disk has no mountpoints the array has a single
+			// null item
+			var mountpoints = disk.mountpoints.filter(
+			    function (mountpoint) {
 				return (mountpoint !== null);
 			});
 


### PR DESCRIPTION
The `mountpoint` property on block devices is now `mountpoints` and is also an array.

If no mountpoints exist, the value is: `[null]`

Also filter out any zvol devices which show up in `lsblk` after a Linux CN has been setup.

See [LINUXCN-26](https://mnx.atlassian.net/browse/LINUXCN-26) for testing notes.

[LINUXCN-26]: https://mnx.atlassian.net/browse/LINUXCN-26?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ