### PR TITLE
OS-8498 Want 'piadm destroy' as an alias for 'piadm remove'

### DIFF
--- a/man/usr/share/man/man8/piadm.8.md
+++ b/man/usr/share/man/man8/piadm.8.md
@@ -12,7 +12,7 @@ piadm(8) -- Manage SmartOS Platform Images
     piadm bootable -e [ -i <source> ] <ZFS-pool-name>
     piadm install <source> [ZFS-pool-name]
     piadm list [ZFS-pool-name]
-    piadm remove <PI-stamp> [ZFS-pool-name]
+    piadm destroy|remove <PI-stamp> [ZFS-pool-name]
     piadm update [ZFS-pool-name]
 
 ## DESCRIPTION
@@ -256,11 +256,15 @@ piadm(8) -- Manage SmartOS Platform Images
         Lists the available platform images (and boot images) on bootable
         pools.
 
+      piadm destroy <PI-stamp> [ZFS-pool-name]
       piadm remove <PI-stamp> [ZFS-pool-name]
 
         The opposite of `install`, and only accepts a PI-stamp.  If a boot
         image exists with the specified PI-stamp, it will also be removed
         unless it is the only boot image available.
+
+	`destroy` and `remove` are synonyms, for those used to other
+	distros' `beadm`.
 
         This command is disallowed on Triton Compute Nodes.
 

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -14,6 +14,7 @@
 #
 # Copyright 2022 Joyent, Inc.
 # Copyright 2022 MNX Cloud, Inc.
+# Copyright 2023 Jason King
 #
 
 # shellcheck disable=1091
@@ -54,7 +55,7 @@ usage() {
 	eecho "    piadm bootable [-d] [-e [-i <source>]] [-r] [ZFS-pool-name]"
 	eecho "    piadm install <source> [ZFS-pool-name]"
 	eecho "    piadm list <-H> [ZFS-pool-name]"
-	eecho "    piadm remove <PI-stamp> [ZFS-pool-name]"
+	eecho "    piadm destroy|remove <PI-stamp> [ZFS-pool-name]"
 	eecho "    piadm update [ZFS-pool-name]"
 	err ""
 }
@@ -1544,7 +1545,7 @@ case $cmd in
 		list "$@"
 		;;
 
-	remove )
+	destroy | remove )
 		privcheck remove
 		standalone_only remove
 		remove "$@"


### PR DESCRIPTION
For those used to beadm(8), adds an alias `destroy` for `remove`.

I've tested it by deleting a PI (verified using `piadm list` before and after deletion.