### PR TITLE
OS-8499: non-flexible_disk bhyve can't set indestructible_zoneroot

### DIFF
--- a/src/vm/node_modules/VM.js
+++ b/src/vm/node_modules/VM.js
@@ -22,7 +22,7 @@
  *
  * Copyright 2021 Joyent, Inc.
  * Copyright 2023 MNX Cloud, Inc.
- * Copyright Spearhead Systems SRL.
+ * Copyright 2023 Spearhead Systems SRL.
  *
  * Experimental functions, expect these interfaces to be unstable and
  * potentially go away entirely:

--- a/src/vm/node_modules/VM.js
+++ b/src/vm/node_modules/VM.js
@@ -1583,7 +1583,11 @@ function setQuotaBhyve(opts, callback) {
                 'set',
                 'quota=' + quota,
                 'reservation=' + quota,
-                'refreservation=' + maxQuota,
+                // We leave 1MiB free on the topmost dataset so it's possible
+                // to make @indestructible snapshots on non-flexible-disk zones.
+                // Without this makeIndestructible() will fail when setting
+                // indestructible_zoneroot=true.
+                'refreservation=' + Math.max(0, maxQuota - 1024 * 1024),
                 dataset
             ];
 

--- a/src/vm/node_modules/VM.js
+++ b/src/vm/node_modules/VM.js
@@ -22,6 +22,7 @@
  *
  * Copyright 2021 Joyent, Inc.
  * Copyright 2023 MNX Cloud, Inc.
+ * Copyright Spearhead Systems SRL.
  *
  * Experimental functions, expect these interfaces to be unstable and
  * potentially go away entirely:


### PR DESCRIPTION
With this change the refreservation on the zoneroot is now 1MiB smaller than before.

Before this patch:

```
[root@e4-43-4b-86-72-ec (ro-1) ~]# zfs get -r refreservation zones/781a2156-b2db-4b88-9bda-01626c900f30
NAME                                              PROPERTY        VALUE      SOURCE
zones/781a2156-b2db-4b88-9bda-01626c900f30        refreservation  1G         local
zones/781a2156-b2db-4b88-9bda-01626c900f30/disk0  refreservation  11.3G      local
zones/781a2156-b2db-4b88-9bda-01626c900f30/disk1  refreservation  54.9G      local
````

After (new VM with same image and package):

```
[root@e4-43-4b-86-72-ec (ro-1) ~]# zfs get -r refreservation zones/654393de-51ad-4bfd-b718-a58ab67aa383
NAME                                              PROPERTY        VALUE      SOURCE
zones/654393de-51ad-4bfd-b718-a58ab67aa383        refreservation  1023M      local
zones/654393de-51ad-4bfd-b718-a58ab67aa383/disk0  refreservation  11.3G      local
zones/654393de-51ad-4bfd-b718-a58ab67aa383/disk1  refreservation  54.9G      local
```

This allows vmadm to set indestructible_zoneroot:

```
[root@e4-43-4b-86-72-ec (ro-1) ~]# zfs list zones/654393de-51ad-4bfd-b718-a58ab67aa383@indestructible
cannot open 'zones/654393de-51ad-4bfd-b718-a58ab67aa383@indestructible': dataset does not exist
[root@e4-43-4b-86-72-ec (ro-1) ~]# vmadm update 654393de-51ad-4bfd-b718-a58ab67aa383 indestructible_zoneroot=true
Successfully updated VM 654393de-51ad-4bfd-b718-a58ab67aa383
[root@e4-43-4b-86-72-ec (ro-1) ~]# zfs list zones/654393de-51ad-4bfd-b718-a58ab67aa383@indestructible
NAME                                                        USED  AVAIL     REFER  MOUNTPOINT
zones/654393de-51ad-4bfd-b718-a58ab67aa383@indestructible      0      -      128K  -
[root@e4-43-4b-86-72-ec (ro-1) ~]# vmadm update 654393de-51ad-4bfd-b718-a58ab67aa383 indestructible_zoneroot=false
Successfully updated VM 654393de-51ad-4bfd-b718-a58ab67aa383
[root@e4-43-4b-86-72-ec (ro-1) ~]# zfs list zones/654393de-51ad-4bfd-b718-a58ab67aa383@indestructible
cannot open 'zones/654393de-51ad-4bfd-b718-a58ab67aa383@indestructible': dataset does not exist
```