### PR TITLE
OS-8501 imgadm will not import active images if they have any inactive origin images

### DIFF
--- a/src/img/lib/sources/imgapi.js
+++ b/src/img/lib/sources/imgapi.js
@@ -21,6 +21,7 @@
  * CDDL HEADER END
  *
  * Copyright (c) 2015, Joyent, Inc. All rights reserved.
+ * Copyright 2023 Spearhead Systems SRL.
  */
 
 var p = console.log;
@@ -227,9 +228,11 @@ ImgapiSource.prototype.getImgAncestry = function getImgAncestry(opts, cb) {
     getNextOrigin(opts.manifest.origin);
 
     function getNextOrigin(uuid) {
+        // We do not want to ensure an origin image is active, since active
+        // leaf images sometimes depend on deactivated origin images.
         var iOpts = {
             arg: uuid,
-            ensureActive: true,
+            ensureActive: false,
             errOn404: true
         };
         self.getImportInfo(iOpts, function (err, importInfo) {


### PR DESCRIPTION
If an image which has children images is disabled, none of those children images can be imported. I bumped into this on a fresh server that didn’t have `b70d5484-5168-4ecb-8127-0a0c59c1d906` (a Ubuntu 20.04 image) on it yet:

```
[root@24-6e-96-5e-b3-9c (ro-1) ~]# imgadm import b70d5484-5168-4ecb-8127-0a0c59c1d906
Importing b70d5484-5168-4ecb-8127-0a0c59c1d906 (ubuntu-20.04.3@20210930) from "http://...snip..."
Gather image b70d5484-5168-4ecb-8127-0a0c59c1d906 ancestry
Uncaught TypeError: Cannot read property 'manifest' of null

FROM
/usr/img/lib/sources/imgapi.js:242:31
/usr/img/lib/sources/imgapi.js:154:9
/usr/img/node_modules/sdc-clients/lib/imgapi.js:698:17
parseResponse (/usr/img/node_modules/restify/lib/clients/json_client.js:84:9)
IncomingMessage.done (/usr/img/node_modules/restify/lib/clients/string_client.js:151:17)
IncomingMessage.g (events.js:180:16)
IncomingMessage.EventEmitter.emit (events.js:117:20)
_stream_readable.js:920:16
process._tickCallback (node.js:415:13)
Abort (core dumped)
```

The problem is that `b70d5484-5168-4ecb-8127-0a0c59c1d906` is an active image, but it has an origin (parent) image `9aa48095-da9d-41ca-a094-31d1fb476b98` which was disabled (it’s Ubuntu 18.04, and now EOL). It makes sense to disable the origin image as a result, but we still want the child image to continue to be deployable.

After talking to some operators, they want the ability to disable an outdated origin image without affecting the availability of all derived images. This change makes that possible.

With this change:

Disabled images still cannot be imported:

```
[root@e4-43-4b-86-6c-8c (ro-1) ~]# imgadm import 9aa48095-da9d-41ca-a094-31d1fb476b98
imgadm import: error (ActiveImageNotFound): an active image "9aa48095-da9d-41ca-a094-31d1fb476b98" was not found in image sources
```

However any child images that depend on it can still be imported:

```
[root@e4-43-4b-86-6c-8c (ro-1) ~]# imgadm import b70d5484-5168-4ecb-8127-0a0c59c1d906
Importing b70d5484-5168-4ecb-8127-0a0c59c1d906 (ubuntu-20.04.3@20210930) from "http://...snip..."
Gather image b70d5484-5168-4ecb-8127-0a0c59c1d906 ancestry
Must download and install 2 images (2.6 GiB)
Downloaded image 9aa48095-da9d-41ca-a094-31d1fb476b98 (348.0 MiB)
...9aa48095-da9d-41ca-a094-31d1fb476b98 [================================================================================>] 100% 348.01MB  29.25MB/s    11s
Download 2 images                       [================================================================================>] 100%   2.64GB  93.68MB/s    28s
Downloaded image b70d5484-5168-4ecb-8127-0a0c59c1d906 (2.2 GiB)
Imported image 9aa48095-da9d-41ca-a094-31d1fb476b98 (ubuntu-certified-18.04@20190627.1.1)
...b70d5484-5168-4ecb-8127-0a0c59c1d906 [================================================================================>] 100%   2.30GB  11.18MB/s  3m30s
Imported image b70d5484-5168-4ecb-8127-0a0c59c1d906 (ubuntu-20.04.3@20210930)
```