### PR TITLE
OS-8525 Installer should explicitly print network address(es)

### DIFF
--- a/src/smartdc/lib/smartos_prompt_config.sh
+++ b/src/smartdc/lib/smartos_prompt_config.sh
@@ -1447,7 +1447,8 @@ if [ $boot_from_zpool == "yes" ]; then
 fi
 
 if [[ $(getanswer "skip_final_confirm") != "true" ]]; then
-	printf "System setup has completed.\n\nPress enter to reboot.\n"
+	printf "\nSSH to host %s or %s.local\n" "" "$hostname"
+	printf "\nSystem setup has completed.\n\nPress enter to reboot.\n"
 	read foo
 fi
 reboot


### PR DESCRIPTION
Stake-in-the-ground. Some decisions that can be easily overturned:

- Don't wish to advertise web UI until it's ready.

- Only printing in cases where final-confirmation is requested.

- No fancy tput/colors/etc.