### PR TITLE
OS-8531 vmadm should create volumes with larger volblocksize on RAIDZ pools with 4K disks

### DIFF
--- a/src/vm/node_modules/VM.js
+++ b/src/vm/node_modules/VM.js
@@ -538,7 +538,7 @@ function getOptimalVolblocksize(log, volPath, callback)
 
         var hasAshift9  = stdout.match('ashift: 9');
         var hasAshift12 = stdout.match('ashift: 12');
-        var hasRaidZ = stdout.match("type: 'raidz'");
+        var hasRaidZ = stdout.match('type: \'raidz\'');
 
         // This is an approximation: we only increase the blocksize if we know
         // that the entire pool is using 4K pages. If even one disk is using

--- a/src/vm/node_modules/VM.js
+++ b/src/vm/node_modules/VM.js
@@ -536,14 +536,28 @@ function getOptimalVolblocksize(log, volPath, callback)
             return;
         }
 
-        var hasAshift9  = stdout.match('ashift: 9');
-        var hasAshift12 = stdout.match('ashift: 12');
+        var hasAshift9  = stdout.match('ashift: 9');  // 512B blocks
+        var hasAshift12 = stdout.match('ashift: 12'); // 4KiB blocks
         var hasRaidZ = stdout.match('type: \'raidz\'');
 
-        // This is an approximation: we only increase the blocksize if we know
-        // that the entire pool is using 4K pages. If even one disk is using
-        // 512b pages (e.g. the data disks are 4K, but the slog is 512b) then
-        // we stick with the default.
+        // This is an approximation: we only increase the volblocksize if we
+        // know that the entire pool is using 4KiB logical disk blocks. If even
+        // one disk is using 512B blocks (e.g. the data disks are 4KiB, but the
+        // slog is 512B) then we stick with the default volblocksize.
+        //
+        // Increasing the volblocksize reduces the size overhead noticeably with
+        // such RAIDZ configurations. Using a default 8KiB volblocksize on a 4K
+        // RAIDZ pool can easily cause 200+% size inflation. Overhead
+        // measurements (detailed in OS-8531) suggest 32KiB is a good larger
+        // block size, reducing overhead to less than 20% for most RAIDZ
+        // configurations. The performance difference in testing between 16KiB
+        // and 32KiB is minimal, and 32KiB volblocksizes are especially
+        // important for reducing inflation with RAIDZ3.
+        //
+        // As an aside: even with this check, stay away from RAIDZ3 pools with
+        // 10 to 13 disks when using volumes. Such configurations can have size
+        // inflation up to 45%, whereas volumes on 14-disk RAIDZ3 pools will
+        // only have 9%.
         var volblocksize = hasAshift12 && !hasAshift9 && hasRaidZ ?
             32768 :
             DEFAULT_VOLBLOCKSIZE;

--- a/src/vm/node_modules/VM.js
+++ b/src/vm/node_modules/VM.js
@@ -518,12 +518,12 @@ function getZpools(log, callback)
     });
 }
 
-function getOptimalVolblocksize(log, path, callback)
+function getOptimalVolblocksize(log, volPath, callback)
 {
     assert.object(log, 'no logger passed to getOptimalVolblocksize()');
-    assert.string(path, 'no volume path passed to getOptimalVolblocksize()');
+    assert.string(volPath, 'no volume path passed to getOptimalVolblocksize()');
 
-    var pool = path.split('/')[0];
+    var pool = volPath.split('/')[0];
     var cmd = '/usr/sbin/zdb';
     var args = ['-C', pool];
 

--- a/src/vm/node_modules/VM.js
+++ b/src/vm/node_modules/VM.js
@@ -518,6 +518,38 @@ function getZpools(log, callback)
     });
 }
 
+function getOptimalVolblocksize(log, callback)
+{
+    var args = ['-C'];
+    var cmd = '/usr/sbin/zdb';
+
+    assert(log, 'no logger passed to zpoolRequiresLargerVolblocksize()');
+
+    traceExecFile(cmd, args, log, 'zdb-c',
+        function (error, stdout, stderr) {
+
+        if (error) {
+            log.error('Unable to get zdb pool data');
+            callback(error, {'stdout': stdout, 'stderr': stderr});
+            return;
+        }
+
+        var hasAshift9  = stdout.match('ashift: 9');
+        var hasAshift12 = stdout.match('ashift: 12');
+        var hasRaidZ = stdout.match("type: 'raidz'")
+
+        // This is an approximation: we only increase the blocksize if we know
+        // that the entire pool(s) is using 4K pages. If even one disk is using
+        // 512b pages (e.g. the data disks are 4K, but the slog is 512b) then
+        // we stick with the default.
+        var volblocksize = hasAshift12 && !hasAshift9 && hasRaidZ ?
+            16384 :
+            DEFAULT_VOLBLOCKSIZE;
+
+        callback(null, volblocksize);
+    });
+}
+
 function validateProperty(brand, prop, value, action, data, errors, log)
 {
     var allowed;
@@ -2359,14 +2391,34 @@ function createVolume(volume, opts, callback)
         refreserv = 'auto';
     }
 
-    createResizeDeleteVolume({
-        log: log,
-        zpds: opts.zpds,
-        volname: volume.zfs_filesystem,
-        newsize: size * 1024 * 1024,
-        getSpaceDeltaFunc: cloning ? getCloneMdSize : getNewMdSize,
-        volChangeFunc: cloning ? cloneVolumeFunc :  createVolumeFunc
-    }, callback);
+    if (cloning) {
+        volblocksizeCb();
+    } else {
+        // we only (potentially) change the volblocksize for new volumes,
+        // since existing volumes (i.e. when cloning) already have a
+        // volblocksize
+        getOptimalVolblocksize(log, volblocksizeCb);
+    }
+
+    function volblocksizeCb(err, vbs) {
+        if (err) {
+            callback(err);
+            return;
+        }
+
+        if (vbs) {
+            volume.block_size = volume.block_size || vbs;
+        }
+
+        createResizeDeleteVolume({
+            log: log,
+            zpds: opts.zpds,
+            volname: volume.zfs_filesystem,
+            newsize: size * 1024 * 1024,
+            getSpaceDeltaFunc: cloning ? getCloneMdSize : getNewMdSize,
+            volChangeFunc: cloning ? cloneVolumeFunc :  createVolumeFunc
+        }, callback);
+    }
 
     // A getSpaceDeltaFunc for createResizeDeleteVolume()
     function getCloneMdSize(_opts, _cb) {

--- a/src/vm/node_modules/VM.js
+++ b/src/vm/node_modules/VM.js
@@ -542,8 +542,8 @@ function getOptimalVolblocksize(log, volPath, callback)
 
         // This is an approximation: we only increase the volblocksize if we
         // know that the entire pool is using 4KiB logical disk blocks. If even
-        // one disk is using 512B blocks (e.g. the data disks are 4KiB, but the
-        // slog is 512B) then we stick with the default volblocksize.
+        // one disk is using 512B blocks (e.g. the data disks are "4K", but the
+        // slog is "512b") then we stick with the default volblocksize.
         //
         // Increasing the volblocksize reduces the size overhead noticeably with
         // such RAIDZ configurations. Using a default 8KiB volblocksize on a 4K
@@ -554,10 +554,10 @@ function getOptimalVolblocksize(log, volPath, callback)
         // and 32KiB is minimal, and 32KiB volblocksizes are especially
         // important for reducing inflation with RAIDZ3.
         //
-        // As an aside: even with this check, stay away from RAIDZ3 pools with
-        // 10 to 13 disks when using volumes. Such configurations can have size
-        // inflation up to 45%, whereas volumes on 14-disk RAIDZ3 pools will
-        // only have 9%.
+        // As an aside: even with this check, stay away from 4K RAIDZ3 pools
+        // with 10 to 13 disks when using volumes. Such configurations can have
+        // size inflation up to 45%, whereas volumes on 14-disk 4K RAIDZ3 pools
+        // will only have 9%.
         var volblocksize = hasAshift12 && !hasAshift9 && hasRaidZ ?
             32768 :
             DEFAULT_VOLBLOCKSIZE;

--- a/src/vm/node_modules/VM.js
+++ b/src/vm/node_modules/VM.js
@@ -21,7 +21,7 @@
  * CDDL HEADER END
  *
  * Copyright 2021 Joyent, Inc.
- * Copyright 2023 Spearhead Systems SRL.
+ * Copyright 2024 Spearhead Systems SRL.
  * Copyright 2024 MNX Cloud, Inc.
  *
  * Experimental functions, expect these interfaces to be unstable and
@@ -518,12 +518,14 @@ function getZpools(log, callback)
     });
 }
 
-function getOptimalVolblocksize(log, callback)
+function getOptimalVolblocksize(log, path, callback)
 {
-    var args = ['-C'];
-    var cmd = '/usr/sbin/zdb';
+    assert.object(log, 'no logger passed to getOptimalVolblocksize()');
+    assert.string(path, 'no volume path passed to getOptimalVolblocksize()');
 
-    assert(log, 'no logger passed to zpoolRequiresLargerVolblocksize()');
+    var pool = path.split('/')[0];
+    var cmd = '/usr/sbin/zdb';
+    var args = ['-C', pool];
 
     traceExecFile(cmd, args, log, 'zdb-c',
         function (error, stdout, stderr) {
@@ -536,14 +538,14 @@ function getOptimalVolblocksize(log, callback)
 
         var hasAshift9  = stdout.match('ashift: 9');
         var hasAshift12 = stdout.match('ashift: 12');
-        var hasRaidZ = stdout.match("type: 'raidz'")
+        var hasRaidZ = stdout.match("type: 'raidz'");
 
         // This is an approximation: we only increase the blocksize if we know
-        // that the entire pool(s) is using 4K pages. If even one disk is using
+        // that the entire pool is using 4K pages. If even one disk is using
         // 512b pages (e.g. the data disks are 4K, but the slog is 512b) then
         // we stick with the default.
         var volblocksize = hasAshift12 && !hasAshift9 && hasRaidZ ?
-            16384 :
+            32768 :
             DEFAULT_VOLBLOCKSIZE;
 
         callback(null, volblocksize);
@@ -2397,7 +2399,7 @@ function createVolume(volume, opts, callback)
         // we only (potentially) change the volblocksize for new volumes,
         // since existing volumes (i.e. when cloning) already have a
         // volblocksize
-        getOptimalVolblocksize(log, volblocksizeCb);
+        getOptimalVolblocksize(log, volume.zfs_filesystem, volblocksizeCb);
     }
 
     function volblocksizeCb(err, vbs) {


### PR DESCRIPTION
A well-known problem with ZFS occurs when RAIDZ is used with 4K disks (rather than the 512b disks that were the norm when RAIDZ was first added): volumes take excessive amounts of space. E.g. if 100GB is used within the volume, the volume itself on disk will be about 200GB. This is particularly relevant for bhyve or KVM zones.

The simplest way around this pathology is increasing the volblocksize. The default volblocksize is 8K; switching to 16K reduces the space overhead to a more manageable 10-60% for most RAIDZ disk layouts (see below). 32K is a possibility too.

This patch checks all vdevs in a pool, and iff all have ashift=12 and a new volume is being created without an explicit volblocksize given will it switch to volblocksize=16K. It is arguably a simplistic patch, since I wanted to minimize changes to VM.js.

IMHO this should have been done within ZFS itself years ago, because SSDs and 4K disks are increasingly the norm. Ah well, there are probably reasons why not, but the 2x+ space loss is too much.

Here's the metadata overhead for RAIDZ2/RAIDZ3 using both volblocksizes:

Field | Description
-- | --
Metadata overhead | Calculated using the formula from within ZFS 
Raw disk space | Sum of all unformatted disk space. We're assuming 100GB per disk here simply to ease calculation; 100GB isn't special in any way, 250 or 500GB would work the same (just bigger).
Usable space | The amount of actual data that can be written to a volume. This is an estimate, since there are other overheads too.
Space efficiency | Usable space divided by raw disk space. 50% efficiency means that for every byte written to a volume we need two total bytes (including parity) on the raw disks.

Metadata overhead for 16K volblocksize with RAIDZ2:

```
Disks   Metadata overhead  Raw disk space  Usable space  Space efficiency
4       1.09               400             183           46%
5       1.13               500             266           53%
6       1.42               600             281           47%
7       1.50               700             333           48%
8       1.60               800             375           47%
9       1.14               900             614           68%
10      1.14               1000            701           70%
11      1.14               1100            789           72%
12      1.14               1200            877           73%
13      1.23               1300            894           69%
14      1.23               1400            976           70%
15      1.23               1500            1057          71%
16      1.23               1600            1138          71%
17      1.23               1700            1220          72%
18      1.23               1800            1301          72%
19      1.23               1900            1382          73%
20      1.23               2000            1463          73%
21      1.23               2100            1545          74%
22      1.23               2200            1626          74%
23      1.33               2300            1579          69%
24      1.33               2400            1654          70%
...
```

Metadata overhead for 32K volblocksize with RAIDZ2:

```
Disks   Metadata overhead  Raw disk space  Usable space  Space efficiency
4       1.09               400             183           46%
5       1.11               500             270           54%
6       1.18               600             339           57%   <- better than 16K
7       1.00               700             500           71%   <- better than 16K
8       1.06               800             566           71%   <- better than 16K
9       1.14               900             614           68%
10      1.14               1000            702           70%
11      1.14               1100            789           72%
12      1.14               1200            877           73%
13      1.23               1300            894           69%
14      1.23               1400            976           70%
15      1.23               1500            1057          71%
16      1.23               1600            1138          71%
17      1.23               1700            1220          72%
18      1.23               1800            1301          72%
19      1.23               1900            1382          73%
20      1.23               2000            1463          73%
21      1.23               2100            1545          74%
22      1.23               2200            1626          74%
23      1.33               2300            1579          69%
24      1.33               2400            1654          70%
...
```

The space efficiency between 16K and 32K pages is identical for RAIDZ2, except for 6-8 disks where 32K has a sizeable advantage. We chose to go with 16K pages due to possible write amplification (but in benchmarks this turns out to not be an issue).

Metadata overhead for 16K volblocksize with RAIDZ3:

```
Disks   Metadata overhead  Raw disk space  Usable space  Space efficiency
4       1.00               400             100           25%
5       1.14               500             175           35%
6       1.41               600             213           36%
7       1.60               700             250           36%
8       1.14               800             439           55%
9       1.23               900             488           54%
10      1.33               1000            526           53%
11      1.33               1100            602           55%
12      1.33               1200            677           56%
13      1.45               1300            690           53%
14      1.45               1400            759           54%
15      1.45               1500            828           55%
16      1.45               1600            897           56%
17      1.45               1700            966           57%
18      1.45               1800            1034          57%
19      1.60               1900            1000          53%
20      1.60               2000            1063          53%
21      1.60               2100            1125          54%
22      1.60               2200            1188          54%
23      1.60               2300            1250          54%
24      1.60               2400            1313          55%
...
```

Metadata overhead for 32K volblocksize with RAIDZ3:

```
Disks   Metadata overhead  Raw disk space  Usable space  Space efficiency
4       1.00               400             100           25%
5       1.14               500             175           35%
6       1.18               600             254           42%
7       1.06               700             377           54%
8       1.14               800             439           55%
9       1.23               900             569           63%
10      1.33               1000            526           53%
11      1.33               1100            602           55%
12      1.33               1200            677           56%
13      1.45               1300            689           53%
14      1.09               1400            1009          72%
15      1.09               1500            1101          73%
16      1.09               1600            1193          75%
17      1.09               1700            1284          75%
18      1.09               1800            1376          76%
19      1.20               1900            1333          70%
20      1.20               2000            1417          71%
21      1.20               2100            1500          71%
22      1.20               2200            1583          72%
23      1.20               2300            1667          73%
24      1.20               2400            1750          73%
...
```

For low numbers of disks, there are a few times when 16K is close to 32K, but overall 32K offers more space. In retrospect perhaps this patch should have used 32K instead of 16K; I no longer recall why I stuck with 16K.

Switching from 8K to 16K volblocksize reduced performance by ~9% in testing (using fio from within bhyve, amongst other things; sadly I cannot find the benchmark details):

volblocksize | Write IOPS | Write KiB/s | Read IOPS | Read KiB/s | fsync() μs latency | ZFS writes | ZFS MiB physically written
-- | -- | -- | -- | -- | -- | -- | --
4k | 2570 | 1285 | 2573 | 1287 | 2381 | 22600 | 377
8k | 2529 | 1265 | 2532 | 1266 | 2448 | 25800 | 381
16k | 2340 | 1170 | 2344 | 1172 | 2665 | 28400 | 388
32k | 2349 | 1175 | 2353 | 1177 | 2671 | 28000 | 401

We've been using this in production for one year.