### PR TITLE
OS-8537 vmadm hangs for 60s and errors when updating internal_metadata_namespaces.

### DIFF
--- a/src/vm/node_modules/VM.js
+++ b/src/vm/node_modules/VM.js
@@ -16552,10 +16552,12 @@ exports.update = function (uuid, payload, options, callback)
 
                 log.debug('processing vmobj key "%s"', key);
 
-                if (key === 'resolvers') {
+                if (key === 'resolvers' ||
+                    key === 'internal_metadata_namespaces') {
+
                     existing = vmobj[key] || [];
-                    assert.arrayOfString(existing, 'existing vmobj.resolvers');
-                    assert.arrayOfString(value, 'new vmobj.resolvers');
+                    assert.arrayOfString(existing, 'existing vmobj.' + key);
+                    assert.arrayOfString(value, 'new vmobj.' + key);
 
                     diff(existing, value).forEach(function (difference) {
                         var o = {

--- a/src/vm/node_modules/VM.js
+++ b/src/vm/node_modules/VM.js
@@ -16552,8 +16552,8 @@ exports.update = function (uuid, payload, options, callback)
 
                 log.debug('processing vmobj key "%s"', key);
 
-                if (key === 'resolvers' ||
-                    key === 'internal_metadata_namespaces') {
+                if (key === 'resolvers'
+                    || key === 'internal_metadata_namespaces') {
 
                     existing = vmobj[key] || [];
                     assert.arrayOfString(existing, 'existing vmobj.' + key);


### PR DESCRIPTION
I observed vmadm hanging 60s when performing certain updates. Specifically:

```
[root@00-0c-29-ea-39-bd ~]# time echo '{"internal_metadata_namespaces":["3"]}' | ./vmadm update 3ea41436-8bd6-4225-b415-33c6cd35faab
first of 1 error: vminfod watchForChanges "VM.js update (3ea41436-8bd6-4225-b415-33c6cd35faab)" timeout exceeded

real    1m0.273s
user    0m0.211s
sys     0m0.117s
```

This patch fixes the above problem.

Interestingly, for this bug the update does successfully occur (e.g. `internal_metadata_namespaces` is updated through `zonecfg`), but `vmadm` simply does not terminate for 60s. Also, this hang only occurs for some fields, not others (e.g. `internal_metadata` or `autoboot` both terminate as expected).

After digging a bit, this is happening due to a problem with comparisons: https://github.com/TritonDataCenter/smartos-live/blob/72896e74a68eb8948db8f19ee29ed0429a97ce2c/src/vm/node_modules/VM.js#L16843-L16865 Certain array fields are flattened into CSVs, but VM.js is using the deserialized representation (read: actual array) internally. So given the example above, the comparison ends up becoming `["foo"] === "foo"`.

Fields potentially affected by this conversion are `flattenable: 'array'`, in proptable.js. This consists of only two fields though: `internal_metadata_namespaces` and `resolvers`, and `resolvers` does not hang because it is explicitly handled: https://github.com/TritonDataCenter/smartos-live/blob/72896e74a68eb8948db8f19ee29ed0429a97ce2c/src/vm/node_modules/VM.js#L16555-L16588 So it appears that `internal_metadata_namespaces` is the only field affected by this particular bug.

The simplest solution was to extend the check for `resolvers` to include `internal_metadata_namespaces`, since the semantics are the same.

Testing change:

```
[root@00-0c-29-ea-39-bd ~]# time echo '{"internal_metadata_namespaces":["4","3"]}' | ./vmadm update 3ea41436-8bd6-4225-b415-33c6cd35faab
Successfully updated VM 3ea41436-8bd6-4225-b415-33c6cd35faab

real    0m0.315s
user    0m0.214s
sys     0m0.100s
[root@00-0c-29-ea-39-bd ~]# vmadm get 3ea41436-8bd6-4225-b415-33c6cd35faab | json internal_metadata_namespaces
[
  "4",
  "3"
]
[root@00-0c-29-ea-39-bd ~]# time echo '{"internal_metadata_namespaces":["4"]}' | ./vmadm update 3ea41436-8bd6-4225-b415-33c6cd35faab
Successfully updated VM 3ea41436-8bd6-4225-b415-33c6cd35faab

real    0m0.303s
user    0m0.204s
sys     0m0.097s
[root@00-0c-29-ea-39-bd ~]# vmadm get 3ea41436-8bd6-4225-b415-33c6cd35faab | json internal_metadata_namespaces
[
  "4"
]
[root@00-0c-29-ea-39-bd ~]# time echo '{"internal_metadata_namespaces":["4"]}' | ./vmadm update 3ea41436-8bd6-4225-b415-33c6cd35faab
Successfully updated VM 3ea41436-8bd6-4225-b415-33c6cd35faab

real    0m0.301s
user    0m0.202s
sys     0m0.098s
[root@00-0c-29-ea-39-bd ~]# vmadm get 3ea41436-8bd6-4225-b415-33c6cd35faab | json internal_metadata_namespaces
[
  "4"
]
```