### PR TITLE
OS-8539 piadm(8) is noisy when /var/piadm/piadm.conf isn't there

### DIFF
--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -206,7 +206,7 @@ config_check() {
 		return
 	fi
 
-        if grep -q us-east.manta.joyent.com $PIADM_CONF ; then
+        if grep -sq us-east.manta.joyent.com $PIADM_CONF ; then
             # If they have a broken config with the stale joyent name,
             # nuke it.
             printf 'WARNING: Removing stale image server ' >&2


### PR DESCRIPTION
Testing notes are in ticket.  Gonna try a fresh install once I've built an ISO locally.