### PR TITLE
OS-8518 Receiving a BHYVE VM fails due to premature ZFS dataset creation

### DIFF
--- a/src/vm/node_modules/VM.js
+++ b/src/vm/node_modules/VM.js
@@ -11650,7 +11650,10 @@ function getAllDatasets(vmobj)
         disk = vmobj.disks[disk];
         if (disk.hasOwnProperty('zfs_filesystem')) {
             disk_dataset = disk.zfs_filesystem;
-            // Don't push if child of top-level zfs_filesystem.
+            // Child datasets of the zone root are automatically
+            // included because of -r (recursive).  If the dataset
+            // name is not a child of the zone root, then add it to
+            // the list of datasets we need to transfer.
             if (topmost_dataset !=
                 disk_dataset.substr(0, topmost_dataset.length)) {
                 datasets.push(disk.zfs_filesystem);
@@ -11747,7 +11750,8 @@ function sendDataset(target, dataset, log, callback)
                     }
                 );
             }, function (cb) {
-                // Use -r for the snapshot, in case of BHYVE datasets.
+                // Use -r for the snapshot, in case of BHYVE, or other VM
+                // types with delegated datasets.
                 zfs(['snapshot', '-r', dataset + '@sending'], log,
                     function (err, fds) {
 

--- a/src/vm/node_modules/VM.js
+++ b/src/vm/node_modules/VM.js
@@ -10697,7 +10697,8 @@ function receiveStdinChunk(type, opts, callback)
                     log.info('Imported dataset ' + chunk_name);
                     // delete 'sending' snapshot
                     var snap = chunk_name + '@sending';
-                    zfs(['destroy', '-F', snap], log, function (err, fds) {
+                    zfs(['destroy', '-r', '-F', snap], log,
+                        function (err, fds) {
                         if (err) {
                             log.warn({err: err},
                                 'Failed to destroy %s: %s',

--- a/src/vm/node_modules/VM.js
+++ b/src/vm/node_modules/VM.js
@@ -11633,15 +11633,27 @@ function getAllDatasets(vmobj)
 {
     var datasets = [];
     var disk;
+    var topmost_dataset;
 
     if (vmobj.hasOwnProperty('zfs_filesystem')) {
-        datasets.push(vmobj.zfs_filesystem);
+        topmost_dataset = vmobj.zfs_filesystem;
+        datasets.push(topmost_dataset);
     }
 
+    // Put a trailing slash to make child-dataset detection easier.
+    topmost_dataset += '/';
+
     for (disk in vmobj.disks) {
+        var disk_dataset;
+
         disk = vmobj.disks[disk];
         if (disk.hasOwnProperty('zfs_filesystem')) {
-            datasets.push(disk.zfs_filesystem);
+            disk_dataset = disk.zfs_filesystem;
+            // Don't push if child of top-level zfs_filesystem.
+            if (topmost_dataset !=
+                disk_dataset.substr(0, topmost_dataset.length)) {
+                datasets.push(disk.zfs_filesystem);
+            }
         }
     }
 
@@ -11721,8 +11733,8 @@ function sendDataset(target, dataset, log, callback)
 
         async.series([
             function (cb) {
-                // delete any existing 'sending' snapshot
-                zfs(['destroy', '-F', dataset + '@sending'], log,
+                // delete any existing 'sending' snapshot, -r for children
+                zfs(['destroy', '-r', '-F', dataset + '@sending'], log,
                     function (err, fds) {
                         // We don't expect this to succeed, since that means
                         // something left an @sending around. Warn if succeeds.
@@ -11734,7 +11746,8 @@ function sendDataset(target, dataset, log, callback)
                     }
                 );
             }, function (cb) {
-                zfs(['snapshot', dataset + '@sending'], log,
+                // Use -r for the snapshot, in case of BHYVE datasets.
+                zfs(['snapshot', '-r', dataset + '@sending'], log,
                     function (err, fds) {
 
                     cb(err);
@@ -11746,8 +11759,9 @@ function sendDataset(target, dataset, log, callback)
             }, function (cb) {
                 var child;
 
+                // Use -R, which enables -p implicitly (documented behavior).
                 child = spawn('/usr/sbin/zfs',
-                    ['send', '-p', dataset + '@sending'],
+                    ['send', '-R', dataset + '@sending'],
                     {customFds: [-1, 1, -1]});
                 child.stderr.on('data', function (data) {
                     var idx;
@@ -11763,7 +11777,8 @@ function sendDataset(target, dataset, log, callback)
                     cb();
                 });
             }, function (cb) {
-                zfs(['destroy', '-F', dataset + '@sending'], log,
+                // Snapshot destruction must recurse to children as well.
+                zfs(['destroy', '-r', '-F', dataset + '@sending'], log,
                     function (err, fds) {
                         if (err) {
                             log.warn(err, 'Unable to destroy ' + dataset

--- a/src/vmunbundle.c
+++ b/src/vmunbundle.c
@@ -1,5 +1,15 @@
 /*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ *
  * Copyright (c) 2019, Joyent, Inc.
+ * Copyright 2024 MNX Cloud, Inc.
  */
 
 #include <errno.h>
@@ -88,7 +98,7 @@ read_bytes(int fd, char *data, size_t bytes)
 size_t
 zfs_receive(int fd, const char * snapshot)
 {
-    char *argv[4] = {"/usr/sbin/zfs", "receive", 0, 0};
+    char *argv[5] = {"/usr/sbin/zfs", "receive", "-F", 0, 0};
     char *evp[1] = {0};
     pid_t pid;
     int stat;
@@ -96,7 +106,7 @@ zfs_receive(int fd, const char * snapshot)
 
     pid = fork();
     if (pid == 0) {
-        argv[2] = (char *)snapshot;
+        argv[3] = (char *)snapshot;
         if (dup2(fd, 0) < 0) {
             perror("dup2()");
             return (1);


### PR DESCRIPTION
Seems like a big hammer, and the answer might be to not prematurely create a ZFS dataset.