### PR TITLE
OS-8567 piadm(8)'s documentation of custom cites BOOTPOOL not BOOTFS

### DIFF
--- a/man/usr/share/man/man8/piadm.8.md
+++ b/man/usr/share/man/man8/piadm.8.md
@@ -72,9 +72,10 @@ piadm(8) -- Manage SmartOS Platform Images
 
 
     The behavior of loader can be controlled by providing loader.conf.local
-    and/or loader.rc.local files in the ${BOOTPOOL}/boot-${VERSION}
-    directory. Loader config files can also be placed in ${BOOTPOOL}/custom,
-    and will be used by all subsequently installed boot images.
+    and/or loader.rc.local files in the ${BOOTFS}/boot-${VERSION}
+    directory. Loader config files can also be placed in ${BOOTFS}/custom,
+    and will be used by all subsequently installed boot images, but not
+    existing ones.
 
     See loader.conf(5) and loader(7) for the format of these files.
 


### PR DESCRIPTION
See bug.