### PR TITLE
OS-8578 Add "-s" option to sdc-factoryreset to poweroff CN instead of reboot

### DIFF
--- a/man/smartdc/man/man1/sdc-factoryreset.1.md
+++ b/man/smartdc/man/man1/sdc-factoryreset.1.md
@@ -3,23 +3,27 @@
 
 ## SYNOPSIS
 
-`sdc-factoryreset [-h | --help]`
+`sdc-factoryreset [-h | --help] {-s}`
 
 
 ## DESCRIPTION
 
 This command resets a machine to its originally installed state.  Specifically,
 it reboots the machine, imports all ZFS pools, and destroys them individually.
-It does this by setting a ZFS user property on the system pool.
+It does this by setting a ZFS user property on the system pool. Using the
+`-s` flag will instead shut down the machine; putting it into a state where
+upon next reboot will import all ZFS pool and destroy them individually.
 
 If this command is invoked unintentionally, an administrator can prevent the
-system from resetting itself by booting in rescue mode (noimport=true as a GRUB
-boot option) and clearing the smartdc:factoryreset property from the var
-dataset.  If the system is booting without the noimport=true GRUB option, the
-only way to stop the pending factory reset is to power cycle the machine, and
-boot again into rescue mode.  The service which does the actual factory reset
-starts well before an administrator would be able to login to the box, even if
-that administrator has console access.
+system from resetting itself by booting in rescue mode (noimport=true as a
+loader boot option) and clearing the smartdc:factoryreset property from the
+var dataset.  Use of the `-s` option makes this easier to accomplish.
+
+If the affected system boots without the noimport=true GRUB option, the only
+way to stop the pending factory reset is to power cycle the machine, and boot
+again into rescue mode.  The service which does the actual factory reset
+starts well before an administrator would be able to login to the box, even
+if that administrator has console access.
 
 
 ## OPTIONS
@@ -27,7 +31,12 @@ that administrator has console access.
 `-h`
     Show the help and usage mesage
 
+`-s`
+    Instead of immediately rebooting, shut down the machine instead
+    (using poweroff(8)).
+
 
 ## COPYRIGHT
 
-sdc-factoryreset Copyright (c) 2014, Joyent, Inc.
+Copyright (c) 2014, Joyent, Inc.
+Copyright 2024 MNX Cloud, Inc.

--- a/man/smartdc/man/man1/sdc-factoryreset.1.md
+++ b/man/smartdc/man/man1/sdc-factoryreset.1.md
@@ -12,14 +12,15 @@ This command resets a machine to its originally installed state.  Specifically,
 it reboots the machine, imports all ZFS pools, and destroys them individually.
 It does this by setting a ZFS user property on the system pool. Using the
 `-s` flag will instead shut down the machine; putting it into a state where
-upon next reboot will import all ZFS pool and destroy them individually.
+upon next reboot, the machine will import all ZFS pool and destroy them
+individually.
 
 If this command is invoked unintentionally, an administrator can prevent the
 system from resetting itself by booting in rescue mode (noimport=true as a
 loader boot option) and clearing the smartdc:factoryreset property from the
 var dataset.  Use of the `-s` option makes this easier to accomplish.
 
-If the affected system boots without the noimport=true GRUB option, the only
+If the affected system boots without the noimport=true loader option, the only
 way to stop the pending factory reset is to power cycle the machine, and boot
 again into rescue mode.  The service which does the actual factory reset
 starts well before an administrator would be able to login to the box, even

--- a/man/smartdc/man/man1/sdc-factoryreset.1.md
+++ b/man/smartdc/man/man1/sdc-factoryreset.1.md
@@ -17,11 +17,11 @@ individually.
 
 If this command is invoked unintentionally, an administrator can prevent the
 system from resetting itself by booting in rescue mode (noimport=true as a
-loader boot option) and clearing the smartdc:factoryreset property from the
-var dataset.  Use of the `-s` option makes this easier to accomplish.
+boot option) and clearing the smartdc:factoryreset property from the var
+dataset.  Use of the `-s` option makes this easier to accomplish.
 
-If the affected system boots without the noimport=true loader option, the only
-way to stop the pending factory reset is to power cycle the machine, and boot
+If the affected system boots without the noimport=true option, the only way
+to stop the pending factory reset is to power cycle the machine, and boot
 again into rescue mode.  The service which does the actual factory reset
 starts well before an administrator would be able to login to the box, even
 if that administrator has console access.

--- a/src/smartdc/bin/sdc-factoryreset.sh
+++ b/src/smartdc/bin/sdc-factoryreset.sh
@@ -45,7 +45,7 @@ while getopts "hs" opt
 do
 	case "$opt" in
 		h)	usage;;
-		s)	final_command="poweroff"; final_verb="Powering off;;
+		s)	final_command="poweroff"; final_verb="Powering off";;
 		*)	usage;;
 	esac
 done

--- a/src/smartdc/bin/sdc-factoryreset.sh
+++ b/src/smartdc/bin/sdc-factoryreset.sh
@@ -53,7 +53,7 @@ done
 trap abort SIGINT
 
 printf "WARNING: This machine will $final_command and destroy its ZFS pools "
-printf "after the next reboot.\n"
+printf "after the next boot.\n"
 
 read -p "Do you want to proceed with the factory reset? (y/n) " -n 1
 

--- a/src/smartdc/bin/sdc-factoryreset.sh
+++ b/src/smartdc/bin/sdc-factoryreset.sh
@@ -53,7 +53,7 @@ done
 trap abort SIGINT
 
 printf "WARNING: This machine will $final_command and destroy its ZFS pools "
-printf "after the next boot.\n"
+printf "during the next boot.\n"
 
 read -p "Do you want to proceed with the factory reset? (y/n) " -n 1
 

--- a/src/smartdc/bin/sdc-factoryreset.sh
+++ b/src/smartdc/bin/sdc-factoryreset.sh
@@ -7,6 +7,7 @@
 
 #
 # Copyright (c) 2014, Joyent, Inc.
+# Copyright 2024 MNX Cloud, Inc.
 #
 
 #
@@ -27,7 +28,7 @@ function abort()
 
 function usage()
 {
-	printf "\nUsage: $myname [-h | --help]\n\n"
+	printf "\nUsage: $myname [-h | --help] {-s}\n\n"
 	printf "Resets a machine to its originally installed state.  See "
 	printf "sdc-factoryreset(1)\nfor more information.\n"
 	exit 1
@@ -37,18 +38,22 @@ if [[ -n $1 ]] && [[ $1 = "--help" ]]; then
 	usage
 fi
 
-while getopts "h" opt
+final_command="reboot"
+final_verb="Rebooting"
+
+while getopts "hs" opt
 do
 	case "$opt" in
 		h)	usage;;
+		s)	final_command="poweroff"; final_verb="Powering off;;
 		*)	usage;;
 	esac
 done
 
 trap abort SIGINT
 
-printf "WARNING: This machine will reboot and destroy its ZFS pools after "
-printf "rebooting.\n"
+printf "WARNING: This machine will $final_command and destroy its ZFS pools "
+printf "after the next reboot.\n"
 
 read -p "Do you want to proceed with the factory reset? (y/n) " -n 1
 
@@ -59,7 +64,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
 	read -p "Are you sure? (y/n) " -n 1
 
 	if [[ $REPLY =~ ^[Yy]$ ]]; then
-		printf "\n\nRebooting in 5 seconds ... "
+		printf "\n\n$final_verb in 5 seconds ... "
 		sleep 5
 		printf "now!\n"
 
@@ -67,7 +72,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
 		[[ -n ${SYS_ZPOOL} ]] || SYS_ZPOOL=zones
 
 		zfs set smartdc:factoryreset=yes ${SYS_ZPOOL}/var
-		reboot
+		$final_command
 	else
 		abort
 	fi


### PR DESCRIPTION
The lower-hanging, lesser-impact, change to `sdc-factoryreset` I'd like to make.