### PR TITLE
Support mediatype application/vnd.docker.distribution.manifest.list.v…

### DIFF
--- a/src/img/node_modules/docker-registry-client/lib/registry-client-v2.js
+++ b/src/img/node_modules/docker-registry-client/lib/registry-client-v2.js
@@ -42,7 +42,10 @@ var MEDIATYPE_MANIFEST_V2
     = 'application/vnd.docker.distribution.manifest.v2+json';
 var MEDIATYPE_MANIFEST_LIST_V2
     = 'application/vnd.docker.distribution.manifest.list.v2+json';
-
+var MEDIATYPE_OCI_MANIFEST_LIST_V1
+    = 'application/vnd.oci.image.index.v1+json';
+var MEDIATYPE_OCI_IMAGE_MANIFEST_V1
+    = 'application/vnd.oci.image.manifest.v1+json';
 
 // --- internal support functions
 
@@ -1224,6 +1227,115 @@ RegistryClientV2.prototype.listTags = function listTags(cb) {
 };
 
 /*
+ * Get an image manifestlist and return a manifist digist. `ref` is a tag.
+ *
+ *   client.getManifest({ref: <tag>}, function (err, manifestRef, res)
+ *   {
+ *   });
+ */
+RegistryClientV2.prototype.getManifestRef = function getManifestRef(opts, cb) {
+    var self = this;
+    assert.object(opts, 'opts');
+    assert.string(opts.ref, 'opts.ref');
+    assert.optionalBool(opts.acceptManifestLists, 'opts.acceptManifestLists');
+    assert.optionalNumber(opts.maxSchemaVersion, 'opts.maxSchemaVersion');
+    assert.func(cb, 'cb');
+
+    var acceptManifestLists = opts.acceptManifestLists;
+    if (typeof (acceptManifestLists) === 'undefined') {
+        acceptManifestLists = self.acceptManifestLists;
+    }
+    var maxSchemaVersion = (opts.maxSchemaVersion || self.maxSchemaVersion);
+    var res, manifest, manifestDigest;
+
+    vasync.pipeline({arg: this, funcs: [
+        function doLogin(_, next) {
+            self.login(next);
+        },
+        function call(_, next) {
+            var headers = self._headers;
+            if (maxSchemaVersion === 2) {
+                var accept = [];
+                if (self._headers.accept) {
+                    // Accept may be a string or an array - we want an array.
+                    if (Array.isArray(self._headers.accept)) {
+                        accept = self._headers.accept.slice(); // a copy
+                    } else {
+                        accept = [self._headers.accept];
+                    }
+                }
+                accept.push(MEDIATYPE_MANIFEST_V2);
+                if (acceptManifestLists) {
+                    accept.push(MEDIATYPE_MANIFEST_LIST_V2);
+                }
+                headers = common.objMerge({}, self._headers, {accept: accept});
+            }
+            self._api.get({
+                path: fmt('/v2/%s/manifests/%s',
+                    encodeURI(self.repo.remoteName),
+                    encodeURI(opts.ref)),
+                headers: headers
+            }, function _afterCall(err, req, res_, manifest_, body) {
+                if (err) {
+                    return next(err);
+                }
+
+                manifest = manifest_;
+
+                if (manifest.schemaVersion === 1) {
+                    try {
+                        var jws = _jwsFromManifest(manifest, body);
+                        // Some v2 registries (Amazon ECR) do not provide the
+                        // 'docker-content-digest' header.
+                        if (res_.headers['docker-content-digest']) {
+                            _verifyManifestDockerContentDigest(res_, jws);
+                        } else {
+                            self.log.debug({headers: res_.headers},
+                                'no Docker-Content-Digest header on ' +
+                                'getManifest response');
+                        }
+                        _verifyJws(jws);
+                    } catch (verifyErr) {
+                        return next(verifyErr);
+                    }
+                }
+
+                if (manifest.schemaVersion > maxSchemaVersion) {
+                    cb(new restifyErrors.InvalidContentError(fmt(
+                        'unsupported schema version %s in %s:%s manifest',
+                        manifest.schemaVersion, self.repo.localName,
+                        opts.ref)));
+                    return;
+                }
+
+                // Get the manifest digest for the correct platform
+                if (manifest.mediaType === MEDIATYPE_MANIFEST_LIST_V2
+                     || manifest.mediaType === MEDIATYPE_OCI_MANIFEST_LIST_V1 ) {
+                    if (!Array.isArray(manifest.manifests) ||
+                            manifest.manifests.length === 0) {
+                        cb(new restifyErrors.InvalidContentError(fmt(
+                            'no manifests in %s:%s manifest list',
+                            self.repo.localName, opts.ref)));
+                        return;
+                    }
+                    for (var i = 0; i < manifest.manifests.length;  i++) {
+                        if (manifest.manifests[i].platform.architecture === 'amd64'
+                             && manifest.manifests[i].platform.os === 'linux') {
+                                manifestDigest = manifest.manifests[i].digest;
+                        }
+                    }
+                }
+
+                res = res_;
+                next();
+            });
+        }
+    ]}, function (err) {
+        cb(err, manifestDigest, res);
+    });
+};
+
+/*
  * Get an image manifest. `ref` is either a tag or a digest.
  * <https://docs.docker.com/registry/spec/api/#pulling-an-image-manifest>
  *
@@ -1604,5 +1716,7 @@ module.exports = {
     login: login,
     digestFromManifestStr: digestFromManifestStr,
     MEDIATYPE_MANIFEST_V2: MEDIATYPE_MANIFEST_V2,
-    MEDIATYPE_MANIFEST_LIST_V2: MEDIATYPE_MANIFEST_LIST_V2
+    MEDIATYPE_MANIFEST_LIST_V2: MEDIATYPE_MANIFEST_LIST_V2,
+    MEDIATYPE_OCI_MANIFEST_LIST_V1: MEDIATYPE_OCI_MANIFEST_LIST_V1,
+    MEDIATYPE_OCI_IMAGE_MANIFEST_V1: MEDIATYPE_OCI_IMAGE_MANIFEST_V1
 };


### PR DESCRIPTION
related to issues #1115 

recent docker images seem to return a manifest list for the /v2/<name>/manifests/<ref> call and not a manifest.
out of the manifest list this fix selects the digest for the manifest with platform architecture=amd64 and os=linux
and than this digest is used to call the manifest again to get the actual manifest with the image layers.


…2+json and application/vnd.oci.image.index.v1+json

For docker images support the manifest.list.v2 and oci.image.index.v1 when getting a manifest for a docker image in de registry-v2 client. When requesting a manifest a manifestList might be returned. In this case select the digest out of the manifestList for the correct platform.

platform needs to be:
  architecture: amd64
  os: linux

if manifest list contains a valid manifest use the digest to get the manifest with image layers.