### PR TITLE
Update README.md: Quickstart only works on SunOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Quickstart
+# Quickstart on SunOS
 
 ```
 git clone https://github.com/TritonDataCenter/smartos-live.git


### PR DESCRIPTION
I tried the Quickstart on macOS but needed to edit the `./configure` shebang from `/usr/bin/bash` to `/bin/bash` but then I got `configure: build only works on SunOS`.

https://github.com/TritonDataCenter/smartos-live/blob/08b04d298c3f85049e85184140cfae5407ec2995/configure#L66