### PR TITLE
TOOLS-2582 Slack channels need renaming or not specifying in Jenkinsfiles, post-EdgeCast-move.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@
 
 /*
  * Copyright 2022 Joyent, Inc.
- * Copyright 2024 MNX Cloud, Inc.
+ * Copyright 2025 MNX Cloud, Inc.
  */
 
 @Library('jenkins-joylib@v1.0.8') _
@@ -197,7 +197,7 @@ export ENGBLD_BITS_UPLOAD_IMGAPI=true
                             cleanWhenNotBuilt: true,
                             deleteDirs: true
                         joySlackNotifications(
-                            channel: 'smartos', comment: 'default')
+                            channel: 'cloud-smartos', comment: 'default')
                     }
                 }
             }
@@ -246,7 +246,7 @@ export PLAT_CONFIGURE_ARGS="-d $PLAT_CONFIGURE_ARGS"
                             cleanWhenNotBuilt: true,
                             deleteDirs: true
                         joySlackNotifications(
-                            channel: 'smartos', comment: 'debug')
+                            channel: 'cloud-smartos', comment: 'debug')
                     }
                 }
             }
@@ -292,7 +292,7 @@ export PLATFORM_DEBUG_SUFFIX=-gcc14
                             cleanWhenNotBuilt: true,
                             deleteDirs: true
                         joySlackNotifications(
-                            channel: 'smartos', comment: 'gcc14')
+                            channel: 'cloud-smartos', comment: 'gcc14')
                     }
                 }
             }
@@ -335,7 +335,7 @@ export MANTA_TOOLS_PATH=/root/bin/
                             cleanWhenNotBuilt: true,
                             deleteDirs: true
                         joySlackNotifications(
-                            channel: 'smartos', comment: 'strap-cache')
+                            channel: 'cloud-smartos', comment: 'strap-cache')
                     }
                 }
             }
@@ -344,10 +344,9 @@ export MANTA_TOOLS_PATH=/root/bin/
     }
     post {
         always {
+            joySlackNotifications(comment: 'pipeline complete')
             joySlackNotifications(
-                channel: 'jenkins', comment: 'pipeline complete')
-            joySlackNotifications(
-                channel: 'smartos', comment: 'pipeline complete')
+                channel: 'cloud-smartos', comment: 'pipeline complete')
         }
     }
 }


### PR DESCRIPTION
NOTE:  I'll be pushing in an upstream illumos merge once this lands.  That illumos merge will ALSO contain TOOLS-2582 for the TritonDataCenter/illumos-joyent repo as well.