### PR TITLE
OS-8655 tests-tar tarball changes owner/permission on ./.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -282,6 +282,10 @@ $(TESTS_MANIFEST): world
 # overwrite the same file in the platform.tgz if they were
 # ever extracted to the same area for investigation. Juggle a bit.
 #
+# Also, we do NOT want a tar file that includes "." in its contents. It could
+# alter $PWD in a bad way. We use a big hammer of excluding all dot-files,
+# which is safe because we don't generate any at the top level directory anyway.
+#
 $(TESTS_TARBALL): $(TESTS_MANIFEST)
 	pfexec rm -f $@
 	pfexec rm -rf $(TESTS_PROTO)
@@ -289,7 +293,7 @@ $(TESTS_TARBALL): $(TESTS_MANIFEST)
 	cp $(STAMPFILE) $(ROOT)/tests.buildstamp
 	pfexec ./tools/builder/builder $(TESTS_MANIFEST) $(TESTS_PROTO) \
 	    $(PROTO) $(ROOT)
-	pfexec gtar -C $(TESTS_PROTO) -I pigz -cf $@ .
+	pfexec ./tools/build_tests_tar $(TESTS_PROTO) > $@
 	rm $(ROOT)/tests.buildstamp
 
 tests-tar: $(TESTS_TARBALL)

--- a/tools/build_tests_tar
+++ b/tools/build_tests_tar
@@ -1,0 +1,37 @@
+#!/usr/bin/bash -x
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# Copyright 2025 MNX Cloud, Inc.
+#
+
+#
+# build_tests_tar - built tests-*.tgz
+#
+# This script exists because we do not want to create a tests-tar that has
+# "." as an entry in its archive.  This can cause damage to $PWD, per OS-8655.
+#
+# Makefiles are a terrible place to invoke subcommands that need Makefile
+# variables inside $(shell ...) subcommands. So we have this script to make
+# things simple for the Makefile. We send the tarfile output to stdout so
+# the Makefile can send it to its proper destination.
+#
+
+
+if [[ "$1" == "" ]]; then
+	echo "usage: $0 TESTS_PROTO_PATH" >& 2
+        exit 1
+fi
+
+# Assume we get called via pfexec or we error out here, and that the
+# Makefile will take this script's stdout to its destination.
+# Use $(ls -1A) to eliminate possiblity of "." as a tar file entry.
+cd "$1"
+gtar -I pigz -cf - $(ls -1A)

--- a/tools/build_tests_tar
+++ b/tools/build_tests_tar
@@ -13,7 +13,7 @@
 #
 
 #
-# build_tests_tar - built tests-*.tgz
+# build_tests_tar - build tests-*.tgz
 #
 # This script exists because we do not want to create a tests-tar that has
 # "." as an entry in its archive.  This can cause damage to $PWD, per OS-8655.
@@ -33,5 +33,5 @@ fi
 # Assume we get called via pfexec or we error out here, and that the
 # Makefile will take this script's stdout to its destination.
 # Use $(ls -1A) to eliminate possiblity of "." as a tar file entry.
-cd "$1"
+cd "$1" || exit 2
 gtar -I pigz -cf - $(ls -1A)


### PR DESCRIPTION
Rewrite that works on Jenkins too.  See https://jenkins.tritondatacenter.com/job/TritonDataCenter/job/smartos-live/job/OS-8655/