### PR TITLE
OS-8653 PIADM(8) could be more verbose/helpful about curl(1) errors.

### DIFF
--- a/man/usr/share/man/man8/piadm.8.md
+++ b/man/usr/share/man/man8/piadm.8.md
@@ -330,15 +330,16 @@ piadm(8) -- Manage SmartOS Platform Images
 
     The following environment variables affect piadm(8) downloads internally.
 
-    PIADM_SUM_URL      If set, the value will be used to retrieve the checksums file, currently
-                            md5sums.txt file, which will used to validate the checksum of downloaded
-                            platform images.
+    PIADM_SUM_URL      If set, this properly-formed URL will be used to retrieve the checksums file.
+                            If not set, the default source of SmartOS PIs has a checksums file,
+                            based on PIADM_DIGEST_ALGORITHM (see below).
+                            The file is a list of {checksum, space, filename} tuples, one per line.
 
     PIADM_NO_SUM       If set to 1, this will skip checksum validation for downloaded platform
                             images.
 
-    PIADM_DIGEST_ALGORITHM  If set, the value will be used by digest(1) to calculate the checksums
-                            for downloaded platform images. By default md5 is used.
+    PIADM_DIGEST_ALGORITHM  If set, this value will be used by digest(1) to calculate checksums for
+                                 downloaded platform images (case sensitive). By default, md5 is used.
 
 ## EXIT STATUS
 

--- a/man/usr/share/man/man8/piadm.8.md
+++ b/man/usr/share/man/man8/piadm.8.md
@@ -326,6 +326,16 @@ piadm(8) -- Manage SmartOS Platform Images
  [root@smartos ~]#
 ```
 
+## ENVIRONMENT VARIABLES
+
+    The following environment variables affect the execution of PIADM(8).
+
+    PIADM_MD5SUM_URL    If set, the value will be used to retrieve the md5sums.txt file, which will
+                        used to validate the MD5 hashes of downloaded platform images.
+
+    PIADM_NO_MD5SUM     If set to 1, this will skip MD5 checksum validation for downloaded platform
+                        images.
+
 ## EXIT STATUS
 
 The following exit values are returned:

--- a/man/usr/share/man/man8/piadm.8.md
+++ b/man/usr/share/man/man8/piadm.8.md
@@ -330,11 +330,14 @@ piadm(8) -- Manage SmartOS Platform Images
 
     The following environment variables affect the execution of PIADM(8).
 
-    PIADM_MD5SUM_URL    If set, the value will be used to retrieve the md5sums.txt file, which will
-                        used to validate the MD5 hashes of downloaded platform images.
+    PIADM_CHECKSUM_URL      If set, the value will be used to retrieve the md5sums.txt file, which will
+                            used to validate the checksum of downloaded platform images.
 
-    PIADM_NO_MD5SUM     If set to 1, this will skip MD5 checksum validation for downloaded platform
-                        images.
+    PIADM_NO_CHECKSUM       If set to 1, this will skip checksum validation for downloaded platform
+                            images.
+
+    PIADM_DIGEST_ALGORITHM  If set, the value will be used by DIGEST(1) to calculate the checksums
+                            for downloaded platform images. By default md5 is used.
 
 ## EXIT STATUS
 

--- a/man/usr/share/man/man8/piadm.8.md
+++ b/man/usr/share/man/man8/piadm.8.md
@@ -328,18 +328,18 @@ piadm(8) -- Manage SmartOS Platform Images
 
 ## ENVIRONMENT VARIABLES
 
-    The following environment variables affect piadm(8) downloads internally.
+The following environment variables affect piadm(8) downloads internally.
 
-    PIADM_SUM_URL      If set, this properly-formed URL will be used to retrieve the checksums file.
-                            If not set, the default source of SmartOS PIs has a checksums file,
-                            based on PIADM_DIGEST_ALGORITHM (see below).
-                            The file is a list of {checksum, space, filename} tuples, one per line.
+     PIADM_SUM_URL           If set, this properly-formed URL will be used to retrieve the checksums file.
+                             If not set, the default source of SmartOS PIs has a checksums file,
+                             based on PIADM_DIGEST_ALGORITHM (see below).
+                             The file is a list of {checksum, space, filename} tuples, one per line.
 
-    PIADM_NO_SUM       If set to 1, this will skip checksum validation for downloaded platform
-                            images.
+     PIADM_NO_SUM            If set to 1, this will skip checksum validation for downloaded platform
+                             images.
 
-    PIADM_DIGEST_ALGORITHM  If set, this value will be used by digest(1) to calculate checksums for
-                                downloaded platform images (case sensitive). By default, md5 is used.
+     PIADM_DIGEST_ALGORITHM  If set, this value will be used by digest(1) to calculate checksums for
+                             downloaded platform images (case sensitive). By default, md5 is used.
 
 ## EXIT STATUS
 

--- a/man/usr/share/man/man8/piadm.8.md
+++ b/man/usr/share/man/man8/piadm.8.md
@@ -330,11 +330,11 @@ piadm(8) -- Manage SmartOS Platform Images
 
     The following environment variables affect piadm(8) downloads internally.
 
-    PIADM_CHECKSUM_URL      If set, the value will be used to retrieve the checksums file, currently
+    PIADM_SUM_URL      If set, the value will be used to retrieve the checksums file, currently
                             md5sums.txt file, which will used to validate the checksum of downloaded
                             platform images.
 
-    PIADM_NO_CHECKSUM       If set to 1, this will skip checksum validation for downloaded platform
+    PIADM_NO_SUM       If set to 1, this will skip checksum validation for downloaded platform
                             images.
 
     PIADM_DIGEST_ALGORITHM  If set, the value will be used by DIGEST(1) to calculate the checksums

--- a/man/usr/share/man/man8/piadm.8.md
+++ b/man/usr/share/man/man8/piadm.8.md
@@ -339,7 +339,7 @@ piadm(8) -- Manage SmartOS Platform Images
                             images.
 
     PIADM_DIGEST_ALGORITHM  If set, this value will be used by digest(1) to calculate checksums for
-                                 downloaded platform images (case sensitive). By default, md5 is used.
+                                downloaded platform images (case sensitive). By default, md5 is used.
 
 ## EXIT STATUS
 

--- a/man/usr/share/man/man8/piadm.8.md
+++ b/man/usr/share/man/man8/piadm.8.md
@@ -337,7 +337,7 @@ piadm(8) -- Manage SmartOS Platform Images
     PIADM_NO_SUM       If set to 1, this will skip checksum validation for downloaded platform
                             images.
 
-    PIADM_DIGEST_ALGORITHM  If set, the value will be used by DIGEST(1) to calculate the checksums
+    PIADM_DIGEST_ALGORITHM  If set, the value will be used by digest(1) to calculate the checksums
                             for downloaded platform images. By default md5 is used.
 
 ## EXIT STATUS

--- a/man/usr/share/man/man8/piadm.8.md
+++ b/man/usr/share/man/man8/piadm.8.md
@@ -328,7 +328,7 @@ piadm(8) -- Manage SmartOS Platform Images
 
 ## ENVIRONMENT VARIABLES
 
-    The following environment variables affect the execution of PIADM(8).
+    The following environment variables affect piadm(8) downloads internally.
 
     PIADM_CHECKSUM_URL      If set, the value will be used to retrieve the md5sums.txt file, which will
                             used to validate the checksum of downloaded platform images.

--- a/man/usr/share/man/man8/piadm.8.md
+++ b/man/usr/share/man/man8/piadm.8.md
@@ -330,8 +330,9 @@ piadm(8) -- Manage SmartOS Platform Images
 
     The following environment variables affect piadm(8) downloads internally.
 
-    PIADM_CHECKSUM_URL      If set, the value will be used to retrieve the md5sums.txt file, which will
-                            used to validate the checksum of downloaded platform images.
+    PIADM_CHECKSUM_URL      If set, the value will be used to retrieve the checksums file, currently
+                            md5sums.txt file, which will used to validate the checksum of downloaded
+                            platform images.
 
     PIADM_NO_CHECKSUM       If set to 1, this will skip checksum validation for downloaded platform
                             images.

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -198,7 +198,7 @@ PIADM_CONF=/var/piadm/piadm.conf
 
 # fetch_csum
 #
-# Fetches a MD5 hash using a platform file as the key.
+# Fetches checksums using a platform file as the key.
 #
 # Arguments:
 #   $1 - URL from where to fetch the PI from. The name of the PI
@@ -230,7 +230,7 @@ fetch_csum() {
 			stamps_url="${URL_PREFIX%/}?limit=1024"
 			stamp=$("${CURL[@]}" "${stamps_url}" |\
 				json -ga -c "this.name.match(/Z$/)" | json -ag name |\
-				sort  | tail -1; exit ${PIPESTATUS[0]})
+				sort  | tail -1; exit "${PIPESTATUS[0]}")
 			code=$?
 			if [[ $code -ne 0 ]]; then
 				eecho "Curl failed fetching PI data from ${stamps_url}"
@@ -245,17 +245,18 @@ fetch_csum() {
 		fi
 		csum_platform=$("${CURL[@]}"  "${csum_url}" |\
 			awk -v pattern="${platform_file}"\
-			'$0 ~ pattern { print $1; exit}'; exit ${PIPESTATUS[0]})
+			'$0 ~ pattern { print $1; exit}'; exit "${PIPESTATUS[0]}")
 		code=$?
 		if [[ $code -ne 0 ]]; then
 			eecho "fetching checksums from ${csum_url}"
+			#force re-calculation of checksum on the next call.
+			csum_platform=""
 			return 1
 		fi
-		echo ${csum_platform}
+		echo "${csum_platform}"
 		return 0
 	else
-		eecho "not recalculating checksum for $1" &>2
-		echo ${csum_platform}
+		echo "${csum_platform}"
 		return 0
 	fi
 }
@@ -446,7 +447,7 @@ install() {
 			/bin/rm -rf "${tdir}"
 			fatal "Curl exit code $code"
 		fi
-		validate_csum $1 "${tdir}/smartos.iso"
+		validate_csum "$1" "${tdir}/smartos.iso"
 		code=$?
 		if [[ $code -ne 0 ]]; then
 			/bin/rm -rf "${tdir}"

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -178,8 +178,8 @@ piname_present_get_bootfs() {
 
 # Defined as a variable in case we need to add parameters (like -s) to it.
 # WARNING:  Including -k for now.
-CURL=( curl -ks -f )
-VCURL=( curl -k -f --progress-bar --show-error)
+CURL=( curl -ks -f --show-error)
+VCURL=( curl -k -f --progress-bar)
 
 vcurl() {
 	if [[ $VERBOSE -eq 1 ]]; then

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -266,7 +266,7 @@ validate_md5sum() {
 		eecho "Could not get md5sum for PI code: ${code}"
 		return 1
 	fi
-	local_md5sum=$(md5sum "${2}" | cut -d' ' -f1; exit ${PIPESTATUS[0]})
+	local_md5sum=$(digest -a md5 "${2}")
 	code=$?
 	if [[ $code -ne 0 ]]; then
 		eecho "md5sum failed for $2"

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -178,7 +178,7 @@ piname_present_get_bootfs() {
 # Defined as a variable in case we need to add parameters (like -s) to it.
 # WARNING:  Including -k for now.
 CURL=( curl -ks -f )
-VCURL=( curl -k -f --progress-bar )
+VCURL=( curl -k -f -S --progress-bar )
 
 vcurl() {
 	if [[ $VERBOSE -eq 1 ]]; then
@@ -397,7 +397,7 @@ install() {
 
 		# Do a URL reality check.
 		vecho "Attempting download of URL $1"
-		vcurl -o "${tdir}/download" "$1"
+		vcurl -o "${tdir}/download" "$1" 2>/dev/null || echo "$1 seems to be a boot stamp"
 		if [[ -e ${tdir}/download ]]; then
 			# Recurse with the downloaded file.
 			dload=$(mktemp)

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -290,7 +290,7 @@ validate_csum() {
 	if [[ "${published_csum}" != "${local_csum}" ]]; then
 		vecho "published_checksum: ${published_csum}"
 		vecho "local_checksum:     ${local_csum}"
-		eecho  "local file does not matches published checksum"
+		eecho  "local file does not match published checksum"
 		return 1
 	fi
 	return 0

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -202,8 +202,8 @@ PIADM_CONF=/var/piadm/piadm.conf
 #
 # Arguments:
 #   $1 - URL from where to fetch the PI from. The name of the PI
-#   		is expected to be the last path component of the URL,
-#   		or the literal string "latest".
+#   	 is expected to be the last path component of the URL,
+#   	 or the literal string "latest".
 #
 # Environment Variables:
 #   PIADM_NO_MD5SUM     - If set to 1, skips MD5 checksum validation.

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -239,7 +239,7 @@ fetch_csum() {
 			platform_file="smartos-${stamp}.iso"
 		fi
 		if [[ -z ${PIADM_SUM_URL} ]];then
-			local csum_url="${URL_PREFIX}${stamp}/md5sums.txt"
+			local csum_url="${URL_PREFIX}${stamp}/${PIADM_DIGEST_ALGORITHM-md5}sums.txt"
 		else
 			local csum_url="${PIADM_SUM_URL}"
 		fi
@@ -251,6 +251,7 @@ fetch_csum() {
 			eecho "fetching checksums from ${csum_url}"
 			#force re-calculation of checksum on the next call.
 			csum_platform=""
+			stamp=""
 			return 1
 		fi
 		echo "${csum_platform}"
@@ -278,7 +279,7 @@ validate_csum() {
 	published_csum=$(fetch_csum "$1")
 	code=$?
 	if [[ $code -ne 0 ]]; then
-		eecho "Could not get checksum for PI code: ${code}"
+		eecho "Could not get checksum for PI exit code: ${code}"
 		return 1
 	fi
 	local_csum=$(digest -a "${PIADM_DIGEST_ALGORITHM-md5}" "${2}")
@@ -521,11 +522,6 @@ install() {
 			dload=$(mktemp)
 			mv -f "${tdir}/download" "$dload"
 			/bin/rm -rf "${tdir}"
-			validate_csum  "$1" "$dload"
-			code=$?
-			if [[ $code -ne 0 ]]; then
-				err "validate_csum exit code  $code"
-			fi
 			# in case `install` exits out early...
 			( pwait $$ ; rm -f "$dload" ) &
 			vecho "Installing $1"

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -512,6 +512,8 @@ install() {
 		# Explicit boot stamp or URL.
 
 		# Check if URL exists first
+		# XXX I think max-time 30s to fetch headers
+		# is more than enough.
 		vecho "Checking if URL $1 exists"
 		if ! "${CURL[@]}" --max-time 30 --connect-timeout \
 				10 --head "$1" > /dev/null 2>&1; then

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -272,7 +272,7 @@ fetch_csum() {
 # algorithm used by DIGEST(1), by default md5 is used.  
 validate_csum() {
 	if [[ $PIADM_NO_SUM -eq 1 ]]; then
-		vecho "WARNING: Not validating checksum"
+		vecho "WARNING: Not using validation checksum"
 		return 0
 	fi
 	published_csum=$(fetch_csum "$1")

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -512,9 +512,9 @@ install() {
 		# Explicit boot stamp or URL.
 
 		# Check if URL exists first
-		# XXX I think max-time 30s to fetch headers
+		# We believe max-time 30s to fetch headers
 		# is more than enough.
-		vecho "Checking if URL $1 exists"
+		vecho "Checking if URL $1 exists (30s) timeout"
 		if ! "${CURL[@]}" --max-time 30 --connect-timeout \
 				10 --head "$1" > /dev/null 2>&1; then
 			# Get HTTP status code for error reporting

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -221,7 +221,7 @@ declare stamp=""
 fetch_csum() {
 	if [[ -z "$csum_platform" ]]; then
 		local platform_file
-		if [ "$1" != "latest" ]; then
+		if [[ "$1" != "latest" ]]; then
 			IFS='/' read -ra array <<< "$1"
 			platform_file="${array[-1]}"
 			stamp="${array[-2]}"

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -288,7 +288,7 @@ validate_csum() {
 	fi
 	if [[ "${published_csum}" != "${local_csum}" ]]; then
 		vecho "published_checksum: ${published_csum}"
-		vecho "local_checksum:     ${local_md5sum}"
+		vecho "local_checksum:     ${local_csum}"
 		eecho  "local file does not matches published checksum"
 		return 1
 	fi

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -239,7 +239,7 @@ fetch_csum() {
 			platform_file="smartos-${stamp}.iso"
 		fi
 		if [[ -z ${PIADM_SUM_URL} ]];then
-			local csum_url="${URL_PREFIX}${stamp}/${PIADM_DIGEST_ALGORITHM-md5}sums.txt"
+			local csum_url="${URL_PREFIX}${stamp}/${PIADM_DIGEST_ALGORITHM:-md5}sums.txt"
 		else
 			local csum_url="${PIADM_SUM_URL}"
 		fi
@@ -282,7 +282,7 @@ validate_csum() {
 		eecho "Could not get checksum for PI exit code: ${code}"
 		return 1
 	fi
-	local_csum=$(digest -a "${PIADM_DIGEST_ALGORITHM-md5}" "${2}")
+	local_csum=$(digest -a "${PIADM_DIGEST_ALGORITHM:-md5}" "${2}")
 	code=$?
 	if [[ $code -ne 0 ]]; then
 		eecho "checksum failed for $2, algorithm used: ${PIADM_DIGEST_ALGORITHM}"

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -13,7 +13,7 @@
 
 #
 # Copyright 2022 Joyent, Inc.
-# Copyright 2024 MNX Cloud, Inc.
+# Copyright 2025 MNX Cloud, Inc.
 #
 
 # shellcheck disable=1091

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -213,7 +213,7 @@ PIADM_CONF=/var/piadm/piadm.conf
 # Notes:
 #   - If "latest" is used, up to 1024 PIs will be listed from ${URL_PREFIX}.
 #     The last one is assumed to be the latest.
-#   - On error, this function exits with code 1, following PIADM(8)
+#   - On error, this function exits with code 1, following piadm(8)
 #     convention: the error indicates a failure, but no changes were made
 #     to the system.
 declare csum_platform=""

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -208,7 +208,7 @@ PIADM_CONF=/var/piadm/piadm.conf
 # Environment Variables:
 #   PIADM_NO_SUM     - If set to 1, skips checksum validation.
 #   PIADM_SUM_URL    - If set, overrides the default URL used
-#                      the checksum file used for platform images.  
+#                      the checksum file used for platform images.
 #
 # Notes:
 #   - If "latest" is used, up to 1024 PIs will be listed from ${URL_PREFIX}.
@@ -268,7 +268,7 @@ fetch_csum() {
 #
 # Error code will always be 1, following the PIADM(8) convention where
 # a return code of 1 means: an error has occurred, but no change was made.
-# Environment variable PIADM_DIGEST_ALGORITHM controls the checksum 
+# Environment variable PIADM_DIGEST_ALGORITHM controls the checksum
 # algorithm used by DIGEST(1), by default md5 is used.  
 validate_csum() {
 	if [[ $PIADM_NO_SUM -eq 1 ]]; then

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -177,6 +177,8 @@ piname_present_get_bootfs() {
 
 # Defined as a variable in case we need to add parameters (like -s) to it.
 # WARNING:  Including -k for now.
+# Including -S (--show-errors) with the intention of making curl's errors
+# easier to parse.
 CURL=( curl -ks -f )
 VCURL=( curl -k -f -S --progress-bar )
 
@@ -397,7 +399,8 @@ install() {
 
 		# Do a URL reality check.
 		vecho "Attempting download of URL $1"
-		vcurl -o "${tdir}/download" "$1" 2>/dev/null || echo "$1 seems to be a boot stamp"
+		vcurl -o "${tdir}/download" "$1"\
+		    2>/dev/null || echo "$1 seems to be a boot stamp"
 		if [[ -e ${tdir}/download ]]; then
 			# Recurse with the downloaded file.
 			dload=$(mktemp)

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -179,7 +179,7 @@ piname_present_get_bootfs() {
 # Defined as a variable in case we need to add parameters (like -s) to it.
 # WARNING:  Including -k for now.
 CURL=( curl -ks -f )
-VCURL=( curl -k -f --progress-bar --show-error)
+VCURL=( curl -k -f --progress-bar)
 
 vcurl() {
 	if [[ $VERBOSE -eq 1 ]]; then

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -178,8 +178,6 @@ piname_present_get_bootfs() {
 
 # Defined as a variable in case we need to add parameters (like -s) to it.
 # WARNING:  Including -k for now.
-# Including -S (--show-errors) with the intention of making curl's errors
-# easier to parse.
 CURL=( curl -ks -f )
 VCURL=( curl -k -f --progress-bar )
 

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -270,7 +270,7 @@ fetch_csum() {
 # Error code will always be 1, following the PIADM(8) convention where
 # a return code of 1 means: an error has occurred, but no change was made.
 # Environment variable PIADM_DIGEST_ALGORITHM controls the checksum
-# algorithm used by DIGEST(1), by default md5 is used.  
+# algorithm used by digest(1), by default md5 is used.  
 validate_csum() {
 	if [[ $PIADM_NO_SUM -eq 1 ]]; then
 		vecho "WARNING: Not using validation checksum"

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -489,8 +489,7 @@ install() {
 
 		# Do a URL reality check.
 		vecho "Attempting download of URL $1"
-		vcurl -o "${tdir}/download" "$1"\
-		    2>/dev/null || echo "$1 seems to be a boot stamp"
+		vcurl -o "${tdir}/download" "$1"
 		if [[ -e ${tdir}/download ]]; then
 			# Recurse with the downloaded file.
 			dload=$(mktemp)

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -358,7 +358,6 @@ EOF
 	# Can furthermore be overridden by the user's PIADM_URL_PREFIX.
 	URL_PREFIX=${PIADM_URL_PREFIX:-${DEFAULT_URL_PREFIX}}
 	
-
 	# Allow environment variables to override config file values
 	[[ -n "${PIADM_DIGEST_ALGORITHM}" ]] && export PIADM_DIGEST_ALGORITHM
 	[[ -n "${PIADM_NO_SUM}" ]] && export PIADM_NO_SUM

--- a/src/piadm.sh
+++ b/src/piadm.sh
@@ -207,8 +207,8 @@ PIADM_CONF=/var/piadm/piadm.conf
 #
 # Environment Variables:
 #   PIADM_NO_SUM     - If set to 1, skips checksum validation.
-#   PIADM_SUM_URL    - If set, overrides the default md5sums.txt URL
-#   					  and uses the value provided.
+#   PIADM_SUM_URL    - If set, overrides the default URL used
+#                      the checksum file used for platform images.  
 #
 # Notes:
 #   - If "latest" is used, up to 1024 PIs will be listed from ${URL_PREFIX}.


### PR DESCRIPTION
The addition of the -S flag (--show-error) in verbose mode could be useful for troubleshooting.