### PR TITLE
OS-8690: smartos-ui does not adapt to changed admin interface IP address

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -354,6 +354,7 @@ LIBSDC_TARGETS = \
 	lib/sdc/zone.sh
 
 ETC_TARGETS = \
+	etc/dhcp/eventhook \
 	etc/nodename \
 	etc/rtc_config \
 	etc/ssh/sshd_config
@@ -401,7 +402,7 @@ install: all $(SUBDIRS)
 	cp -p $(LIBSDC_TARGETS) $(DESTDIR)/lib/sdc/
 	mkdir -p $(DESTDIR)/smartdc/lib
 	cp -p $(SMARTDC_LIB_TARGETS) $(DESTDIR)/smartdc/lib
-	mkdir -p $(DESTDIR)/etc/ssh $(DESTDIR)/etc/notices
+	mkdir -p $(DESTDIR)/etc/ssh $(DESTDIR)/etc/notices $(DESTDIR)/etc/dhcp
 	for file in $(ETC_TARGETS); do \
 		cp -r $$file $(DESTDIR)/$$file; \
 	done

--- a/src/etc/dhcp/eventhook
+++ b/src/etc/dhcp/eventhook
@@ -18,6 +18,14 @@
 # This only applies in the global zone!
 [[ $(zonename) == global ]] || exit 0
 
+# We don't care which interface. If any GZ IPs have changed
+# then we want to update the sysinfo cache.
+#INTERFACE=$1
+
+# We only support this for the BOUND/BOUND6 actions.
+ACTION=$2
+[[ "$ACTION" == BOUND* ]] || exit 0
+
 # Refresh the sysinfo cache
 sysinfo -u
 

--- a/src/etc/dhcp/eventhook
+++ b/src/etc/dhcp/eventhook
@@ -29,7 +29,8 @@ ACTION=$2
 # Refresh the sysinfo cache
 sysinfo -u
 
-# Restart any affected services that depend on sysinfo
+# Restart any affected services currently known to depend on binding to the
+# Admin_IP obtained from sysinfo.
 # (Note that if any of these services do not exist
 # then they just won't show up on stdout.)
 svcs -Ho fmri vmadmd smartos-ui smartos-ui-executor | while read -r service

--- a/src/etc/dhcp/eventhook
+++ b/src/etc/dhcp/eventhook
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 Edgecast Cloud LLC.
+#
+
+# This only applies in the global zone!
+[[ $(zonename) == global ]] || exit 0
+
+# Refresh the sysinfo cache
+sysinfo -u
+
+# Restart any affected services that depend on sysinfo
+# (Note that if any of these services do not exist
+# then they just won't show up on stdout.)
+svcs -Ho fmri vmadmd smartos-ui smartos-ui-executor | while read -r service
+do
+	svcadm restart "$service"
+done

--- a/src/manifest
+++ b/src/manifest
@@ -1072,6 +1072,8 @@ s usr/lib/amd64/libdemangle.so=libdemangle.so.1
 f usr/lib/amd64/libiostream.so.1 0755 root bin
 # 0-livesrc-stamp
 f .smartdc_version 0444 root root
+d etc/dhcp 0755 root sys
+f etc/dhcp/eventhook 0755 root sys
 d etc/ssh 0755 root sys
 f etc/ssh/sshd_config 0644 root sys
 f etc/rtc_config 0644 root root


### PR DESCRIPTION
Fixes tritondatacenter/smartos-ui#19

With this change applied:
```
[root@smartos ~]# svcs vmadmd smartos-ui smartos-ui-executor
STATE          STIME    FMRI
online         19:06:31 svc:/system/smartdc/vmadmd:default
online         19:06:31 svc:/system/smartdc/smartos-ui-executor:default
online         19:06:31 svc:/system/smartdc/smartos-ui:default
[root@smartos ~]# dladm create-vnic -l ixgbe0 dhcptest0
[root@smartos ~]# ifconfig dhcptest0 plumb up
[root@smartos ~]# ifconfig dhcptest0 dhcp
[root@smartos ~]# svcs vmadmd smartos-ui smartos-ui-executor
STATE          STIME    FMRI
online         19:08:47 svc:/system/smartdc/smartos-ui-executor:default
online         19:08:47 svc:/system/smartdc/smartos-ui:default
online         19:08:47 svc:/system/smartdc/vmadmd:default
[root@smartos ~]# ifconfig dhcptest0 down
[root@smartos ~]# ifconfig dhcptest0 unplumb
[root@smartos ~]# dladm delete-vnic dhcptest0
```