### PR TITLE
Fix gcc14-debug release builds with a bit more space in /.

### DIFF
--- a/tools/build_live
+++ b/tools/build_live
@@ -790,7 +790,7 @@ bi_setup_work_dir
 # Create and mount the "/" (root) ramdisk image:
 #
 bi_file_root="$bi_tmpdir/root.image"
-bi_root_size=350000
+bi_root_size=360000
 if strings "$bi_wsroot/proto/kernel/amd64/genunix" |
     grep "DEBUG enabled" >/dev/null; then
 	#


### PR DESCRIPTION
I forgot to mainline this back into `master` with my recent surprise trip.  It's been tested in 20260806 and the gcc14 build of 20260820 is getting rebuilt with this in it.